### PR TITLE
Communicate sticky state to parent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+example/build

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ app.jsx
 Note:
 For more information on the style object see <http://facebook.github.io/react/tips/inline-styles.html>
 
+To communicate to the parent element that the sticky state has changed, pass in a callback function as the `onStickyStateChange` prop:
+
+app.jsx
+```js
+<Sticky onStickyStateChange={this.handleStickyStateChange}>
+  <header />
+</Sticky
+```
+
 A more in-depth example is included, but you will need to build it first using the following command:
 ```sh
 scripts/build-example

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Captivation Software (@teamcaptivation)
 
 Aaron Goin
 
+Josh Carr (@joshcarr)
+
 By all means, if you see room for improvement, let us know!
 
 ## License

--- a/components/sticky.js
+++ b/components/sticky.js
@@ -10,13 +10,20 @@ var React = require('react'),
   },
 
   handleResize: function() {
+    this.props.onStickyStateChange( false );
     // set style with callback to reset once style rendered succesfully
     this.setState({ style: {} }, this.reset);
   },
 
   handleScroll: function() {
-    if (window.pageYOffset > this.elementOffset) this.setState({ style: this.props.stickyStyle });
-    else this.setState({ style: {} });
+    if (window.pageYOffset > this.elementOffset){
+      this.props.onStickyStateChange( true );
+      this.setState({ style: this.props.stickyStyle });
+    }
+    else{
+      this.props.onStickyStateChange( false );
+      this.setState({ style: {} });
+    }
   },
 
   getDefaultProps: function() {
@@ -26,7 +33,8 @@ var React = require('react'),
         top: 0,
         left: 0,
         right: 0
-      }
+      },
+      onStickyStateChange: function () {}
     };
   },
 

--- a/example/app.jsx
+++ b/example/app.jsx
@@ -2,10 +2,13 @@ var React = require('react'),
   Sticky = require('../index');
 
 var App = React.createClass({
+  handleStickyStateChange: function ( state ) {
+    console.log( state );
+  },
   render: function() {
     return (
       <div>
-        <Sticky>
+        <Sticky onStickyStateChange={this.handleStickyStateChange}>
           <header>
             Header (sticky) 
           </header>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "contributors": [{
     "name": "Aaron Goin",
     "email": "aarondgoin@gmail.com"
+  },
+  {
+    "name": "Josh Carr",
+    "email": "joshcarr@gmail.com"
   }],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Adds a `onStickyStateChange` prop option so that the Sticky element can communicate its sticky state to it's parent element.