### PR TITLE
remove `shouldComponentUpdate` (fixes #7)

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -60,12 +60,7 @@ var Sticky = React.createClass({
     window.removeEventListener('resize', this.handleEvent);
   },
 
-  shouldComponentUpdate: function() {
-    return this.state.isSticky !== this.lastState.isSticky;
-  },
-
   render: function() {
-    this.lastState = this.state;
     return this.props.type({
       style: this.state.style,
       className: this.state.className


### PR DESCRIPTION
As @dcramer pointed out, the `shouldComponentUpdate` that was provided does not account for changes in child element props or state. Removing it fixes issues I encountered in my project.