### PR TITLE
switch from handleEvent to rAF loop

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -31,10 +31,25 @@ var Sticky = React.createClass({
     this.elementOffset = this.getDOMNode().getBoundingClientRect().top + windowOffset;
   },
 
-  handleEvent: function() {
-    var wasSticky = this.state.isSticky;
-    var isSticky = window.pageYOffset > this.elementOffset;
-    var nextState = { isSticky: isSticky };
+  checkStickyState: function() {
+    var wasSticky = this.state.isSticky,
+        doc       = document.documentElement,
+        pageY     = (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0);
+    
+    // if current scroll position the same as previous one
+    if (pageY === this.previousPageYOffset) {
+      // lets increase the count of this "nothing to do" circumstance
+      this.stickyCheckCnt++;
+      // if it is already half a second with nothing changed (1000/16/2)
+      //   take a nap and wait on events that were binded in componentDidMount
+      //   method and return immediately
+      // otherwise call self recursively thru requestAnimationFrame
+      //   and return immediately
+      return (this.stickyCheckCnt > 31) ? this.stopLoop() : this.requestFrame();
+    }
+
+    var isSticky = pageY > this.elementOffset,
+        nextState = { isSticky: isSticky };
     if (isSticky) {
       nextState.style = this.props.stickyStyle;
       nextState.className = this.props.stickyClass;
@@ -46,21 +61,47 @@ var Sticky = React.createClass({
     if (isSticky !== wasSticky) {
       this.props.onStickyStateChange(isSticky);
     }
+    // save previous scrollPosition
+    this.previousPageYOffset = pageY;
+    // call itself recursively thru requestAnimationFrame
+    this.requestFrame();
   },
 
   componentDidMount: function() {
     this.reset();
+    // see checkStickyState metod for this variable purpose
+    this.stickyCheckCnt = 0;
+    // start loop where we will checkStickyState
+    this.startLoop();
     this.state.events.forEach(function(type) {
-      window.addEventListener(type, this.handleEvent);
+      window.addEventListener(type, this.startLoop);
     }, this);
   },
-
   componentWillUnmount: function() {
+    // stop loop where we are checking checkStickyState
+    this.stopLoop();
     this.state.events.forEach(function(type) {
-      window.removeEventListener(type, this.handleEvent);
+      window.removeEventListener(type, this.startLoop);
     }, this);
   },
-
+  startLoop: function() {
+    // start the loop only if it isn't running yet
+    if (this.isLoopRunning) { return }; this.isLoopRunning = true;
+    this.requestFrame();
+  },
+  stopLoop: function() {
+    // stop the next frame from firing
+    // needs https://github.com/darius/requestAnimationFrame polyfill
+    // to work in legacy browsers
+    cancelAnimationFrame(this.requestID);
+    // reset flags, see checkStickyState method
+    // for this.stickyCheckCnt purpose
+    this.isLoopRunning = false; this.stickyCheckCnt = 0;
+  },
+  requestFrame: function () {
+    // requst checkStickyState method thru requestAnimationFrame callback
+    this.requestID = requestAnimationFrame(this.checkStickyState);
+  },
   render: function() {
     return this.props.type({
       style: this.state.style,
@@ -70,3 +111,4 @@ var Sticky = React.createClass({
 });
 
 module.exports = Sticky;
+


### PR DESCRIPTION
Hey guys! Thanks for the component!

There is the issue I stumbled upon: [video in mov format](http://monosnap.com/file/0MzTUixmuttii7aLYIlhZJMMaRrQDT)

 *When scrolling too fast, component remains sticked until the next scroll event(or one of the 3 that will run handleEvent method).*

So what I did:
- Switched to requestAnimationFrame loop to check state of component in loop every 16ms. This checks the state exactly when browser is about to render a frame, so it is much more robust approach to rely on (scroll event can fire in a half a frame or fire not often causing flickering etc).
The rAF loop also adds legacy iOS support since scroll fires only on the start and the end of actual scroll process in iOS < 8 versions (http://developer.telerik.com/featured/scroll-event-change-ios-8-big-deal/).
- Since it will always run the loop I did optimisations for it (it costs about `0.15ms` without optimisations):
  - it caches the previous `pageYOffset` value and returns from the loop immediately if nothing changed. It decreases loop cost overhead to about `0.1ms - 0.08ms`.
  - if nothing changes for 500ms - stop the loop and sleep until any of `'load', 'scroll', 'resize'` events fires. It decreases loop cost overhead to about `0ms`.
- Also added `pageY = (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0);` for IE8 support since `React` do support it.

This approach is much more robust with no (or even with better) performance overhead but relies on [requestAnimationFrame polyfill](https://github.com/darius/requestAnimationFrame) for legacy browsers. If you are using an animation library it is probably polyfilled already. I didnt include the polyfill to the component in this PR.

P.S.    This is video after the changes maybe it will help to convince you to merge the PR: [video in mov format](http://take.ms/UbDT8)
P.P.S  I forgot to bump the component's version, sorry about that

