### PR TITLE
[ong] add configuration for offset comparison

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -12,6 +12,9 @@ var Sticky = React.createClass({
         left: 0,
         right: 0
       },
+      stickyConfig: {
+        offset: 0
+      },
       onStickyStateChange: function () {}
     };
   },
@@ -33,7 +36,7 @@ var Sticky = React.createClass({
 
   handleEvent: function() {
     var wasSticky = this.state.isSticky;
-    var isSticky = window.pageYOffset > this.elementOffset;
+    var isSticky = (window.pageYOffset + this.props.stickyConfig.offset) > this.elementOffset;
     var nextState = { isSticky: isSticky };
     if (isSticky) {
       nextState.style = this.props.stickyStyle;


### PR DESCRIPTION
I might be crazy, but it seems like you can only trigger the sticky state when the element hits the top of the page. It would be nice to be able to configure this.