### PR TITLE
Fix issue where requestAnimationFrame is not defined

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -88,7 +88,7 @@ var Sticky = React.createClass({
 
 
   isModernBrowser: function() {
-    return requestAnimationFrame && cancelAnimationFrame;
+    return window.requestAnimationFrame && window.cancelAnimationFrame;
   },
 
   cancel: function() {


### PR DESCRIPTION
IE9 and other environments without requestAnimationFrame are bombing out on this check.