### PR TITLE
Sticky is sometimes not initialized

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -21,7 +21,8 @@ var Sticky = React.createClass({
   getInitialState: function() {
     return {
       events: ['load', 'scroll', 'resize', 'touchmove', 'touchend'],
-      style: {}
+      style: {},
+      className: this.props.className
     };
   },
 


### PR DESCRIPTION
Under certain condition Sticky component is not initialized. That means that className or style is not set for Sticky component.
Here is a demo https://jsfiddle.net/Halama/Le8trz6e/1/

Problem is that event which triggers initialization is not fired https://github.com/captivationsoftware/react-sticky/blob/538bbf3603d674ea6e884e5278e9db36dc34a3ce/sticky.js#L45

I have fixed it in this PR by setting className in getInitialState, it works for our use cases, but I think that better solution would be somehow force `handleTick` to run after `componentDitMount`. I have tried add `this.hasUnhandledEvent = true;` before https://github.com/captivationsoftware/react-sticky/blob/538bbf3603d674ea6e884e5278e9db36dc34a3ce/sticky.js#L78 to force the intialization but i was getting `Cannot read property 'firstChild' of ..` error #17 

thanks
M 

