### PR TITLE
zIndex defaults to 1

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -12,7 +12,8 @@ var Sticky = React.createClass({
         position: 'fixed',
         top: 0,
         left: 0,
-        right: 0
+        right: 0,
+        zIndex: 1
       },
       topOffset: 0,
       onStickyStateChange: function () {}


### PR DESCRIPTION
Sets the default zIndex to 1, it solves issues where items float above the sticky. 