### PR TITLE
Add bottomOffset option

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -100,6 +100,7 @@ var Sticky = React.createClass({
         zIndex: 1
       },
       topOffset: 0,
+      bottomOffset: 0,
       onStickyStateChange: function () {}
     };
   },
@@ -138,6 +139,10 @@ var Sticky = React.createClass({
    * Returns true/false depending on if this should be sticky.
    */
   shouldBeSticky: function() {
+    var offset = this.pageOffset()
+    if (this.props.bottomOffset > 0) {
+      return ((offset >= this.origin + this.props.topOffset) && (offset <= this.props.bottomOffset))
+    }
     return this.pageOffset() >= this.origin + this.props.topOffset;
   },
   /*


### PR DESCRIPTION
- useful if you want to disable stickyness after activating.
- basically having a range where you can show the component, instead of all the way to the bottom.
- fixes #30