### PR TITLE
add component height to pageOffset when component is sticky

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -126,7 +126,8 @@ var Sticky = React.createClass({
         otherStickyOffsets += otherSticky.domNode.getBoundingClientRect().height;
       }
     }
-    return (window.pageYOffset || document.documentElement.scrollTop) + otherStickyOffsets;
+    var componentHeight = this.state.isSticky ? this.domNode.getBoundingClientRect().height : 0;
+    return (window.pageYOffset || document.documentElement.scrollTop) + otherStickyOffsets + componentHeight;
   },
   /*
    * Returns the y-coordinate of the top of this element.


### PR DESCRIPTION
Sometimes if you reach the end of the page, the component flickers because it changes position to sticky and when calculating again the offset,  doesn't take into account it's height. This causes it to move back to normal position and flicker.