### PR TITLE
Added: Stick to bottom functionality

### DIFF
--- a/lib/sticky.js
+++ b/lib/sticky.js
@@ -51,6 +51,13 @@ var Sticky = React.createClass({
       return Sticky.__instances.slice(0, Sticky.__instances.indexOf(instance));
     },
     /*
+     * Return every Sticky instance that is
+     * positioned above the supplied instance.
+     */
+    instancesBelow: function(instance) {
+      return Sticky.__instances.slice(Sticky.__instances.indexOf(instance));
+    },
+    /*
      * Returns true if the browser environment can support
      * requestAnimationFrame. Otherwise returns false;
      */
@@ -100,6 +107,8 @@ var Sticky = React.createClass({
         zIndex: 1
       },
       topOffset: 0,
+      bottomOffset: 0,
+      bottomSticky: false,
       onStickyStateChange: function () {}
     };
   },
@@ -129,16 +138,48 @@ var Sticky = React.createClass({
     return (window.pageYOffset || document.documentElement.scrollTop) + otherStickyOffsets;
   },
   /*
+   * Return the distance of the scrollbar from the
+   * bottom of the window plus the total height of all
+   * stuck Sticky instances below this one.
+   */
+  pageOffsetFromBottom: function() {
+    var otherStickies = Sticky.instancesBelow(this);
+    var otherStickyOffsets = 0;
+    for (var i = 0; i < otherStickies.length; i++) {
+      var otherSticky = otherStickies[i];
+      if (otherSticky.state.isSticky) {
+        otherStickyOffsets += otherSticky.domNode.getBoundingClientRect().height;
+      }
+    }
+    var scrollPosition = window.pageYOffset;
+    var windowSize     = window.innerHeight;
+    var bodyHeight     = document.body.offsetHeight; //tnr: we might want to allow users to pass something other than body here?
+    return Math.max(bodyHeight - (scrollPosition + windowSize), 0) + otherStickyOffsets;
+  },
+  /*
    * Returns the y-coordinate of the top of this element.
    */
   top: function() {
     return this.domNode.getBoundingClientRect().top;
   },
   /*
+   * Returns the y-coordinate of the bottom of this element.
+   */ 
+  bottom: function() {
+    var windowSize     = window.innerHeight;
+    var bottomOfElement = this.domNode.getBoundingClientRect().bottom
+    return windowSize - bottomOfElement;
+  },
+  /*
    * Returns true/false depending on if this should be sticky.
    */
   shouldBeSticky: function() {
-    return this.pageOffset() >= this.origin + this.props.topOffset;
+    if (this.props.bottomSticky) {
+      var comparison = this.origin + this.props.bottomOffset;
+      return this.pageOffsetFromBottom() >= comparison
+    } else {
+      return this.pageOffset() >= this.origin + this.props.topOffset;
+    }
   },
   /*
    * Loop iteration for this instance.
@@ -191,7 +232,9 @@ var Sticky = React.createClass({
       }
     }, this);
     this.domNode = ReactDOM.findDOMNode(this);
-    this.origin = this.top() + this.pageOffset();
+    this.origin = this.props.bottomSticky
+      ? this.bottom() + this.pageOffsetFromBottom()
+      : this.top() + this.pageOffset();
     this.hasUnhandledEvent = true;
     Sticky.register(this);
   },


### PR DESCRIPTION
First pass at solving #41 

Two new props:
bottomOffset=0,
bottomSticky=false

If bottomSticky=true, the component will become sticky only once it has
been scrolled above its bottom.

I think this could still use a bit of refinement, as well as some tests, but it is a start, and introduces no breaking changes.