### PR TITLE
fix to only call setState when new state is different than current state

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -37,7 +37,6 @@ export default class Container extends React.Component {
   }
 
   updateOffset(offset) {
-	  if(this.state.offset === offset) return;
     this.setState({ offset });
   }
 

--- a/src/container.js
+++ b/src/container.js
@@ -37,6 +37,7 @@ export default class Container extends React.Component {
   }
 
   updateOffset(offset) {
+	  if(this.state.offset === offset) return;
     this.setState({ offset });
   }
 

--- a/src/sticky.js
+++ b/src/sticky.js
@@ -56,7 +56,10 @@ export default class Sticky extends React.Component {
     const pageY = window.pageYOffset;
     const origin = this.getOrigin(pageY);
     const isSticky = this.isSticky(pageY, origin);
-    this.setState({ height, origin, isSticky });
+
+	  const s = this.state;
+	  if(s.height !== height || s.origin !== origin || s.isSticky !== isSticky)
+      this.setState({ height, origin, isSticky });
   }
 
   isSticky(pageY, origin) {
@@ -71,7 +74,10 @@ export default class Sticky extends React.Component {
     const isSticky = this.isSticky(pageY, this.state.origin);
     const hasChanged = this.state.isSticky !== isSticky;
 
-    this.setState({ isSticky, origin, height });
+	  const s = this.state;
+	  if(s.height !== height || s.origin !== origin || s.isSticky !== isSticky)
+	    this.setState({ isSticky, origin, height });
+
     this.context.container.updateOffset(isSticky ? this.state.height : 0);
 
     if (hasChanged) this.props.onStickyStateChange(isSticky);
@@ -80,7 +86,10 @@ export default class Sticky extends React.Component {
   onResize = () => {
     const height = ReactDOM.findDOMNode(this).getBoundingClientRect().height;
     const origin = this.getOrigin(window.pageYOffset);
-    this.setState({ height, origin });
+
+	  const s = this.state;
+	  if(s.height !== height || s.origin !== origin)
+	    this.setState({ height, origin });
   }
 
   on(events, callback) {


### PR DESCRIPTION
I've just started playing with react-sticky, and in my case the scrollable area was a very complex list and component hierarchy, and didn't have any `shouldComponentUpdate` optimizations. Without react-sticky, the page rendered well fast enough to be usable and scrolled fine; granted it only had to render once, and the whole page scrolled.

When I added react-sticky, scrolling the complex list lagged so badly it wasn't usable at all. I started stepping through the code, to pinpoint where the bottleneck was, and discovered this one line change to `StickyContainer@updateOffest` allowed the scroll area to scroll very speedy and smoothly. I stopped looking after that (glad I didn't yet need optimize with `shouldComponentUpdate`), so I can only guess it was because calling `updateOffset()` was always calling `setState()` even when the `offset` didn't change, which essentially was causing all the children to `render()` on every scroll event.

Update
Same fix was applied to all calls to `setState()` in both `<Sticky>` and `<StickyContainer>`
