### PR TITLE
Listen to events on the container element as well as the window

### DIFF
--- a/src/sticky.js
+++ b/src/sticky.js
@@ -52,7 +52,7 @@ export default class Sticky extends React.Component {
   }
 
   getXOffset() {
-    return this.refs.placeholder.getBoundingClientRect().left; 
+    return this.refs.placeholder.getBoundingClientRect().left;
   }
 
   getWidth() {
@@ -103,14 +103,20 @@ export default class Sticky extends React.Component {
   onResize = this.onScroll;
 
   on(events, callback) {
+    const node = this.context.container && ReactDOM.findDOMNode(this.context.container)
+
     events.forEach((evt) => {
       window.addEventListener(evt, callback);
+      node && node.addEventListener(evt, callback);
     });
   }
 
   off(events, callback) {
+    const node = this.context.container && ReactDOM.findDOMNode(this.context.container)
+
     events.forEach((evt) => {
       window.removeEventListener(evt, callback);
+      node && node.removeEventListener(evt, callback);
     });
   }
 

--- a/test/unit/sticky.js
+++ b/test/unit/sticky.js
@@ -21,7 +21,7 @@ describe('Sticky component', function() {
     // Mock out some commonly called functions (override them again later as needed)
     this.sticky.context.offset = 0;
     this.sticky.context.rect = {};
-    this.sticky.context.container = { updateOffset: () => {} }
+    this.sticky.context.container = this.stickyContainer
   });
 
   afterEach(() => {
@@ -158,7 +158,7 @@ describe('Sticky component', function() {
 
     it ('should report its height to its container', () => {
       let contextOffset = 0;
-      this.sticky.context.container = { updateOffset: (offset) => { contextOffset = offset; } }
+      this.sticky.context.container = Object.assign({}, this.stickyContainer, { updateOffset: (offset) => { contextOffset = offset; } })
       this.sticky.setState({ origin: 100, height: 100 });
       this.sticky.getHeight = () => 100;
 


### PR DESCRIPTION
This is a first attempt at trying to address https://github.com/captivationsoftware/react-sticky/issues/61, i.e. stickiness within a parent element which does not send down window scroll events. This works for me, but I'd love to hear if it works for other folks as well. It should be non-destructive as it simply listens in more places, but I could definitely imagine this adding overhead.