### PR TITLE
Fix test setup

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -1,16 +1,19 @@
-// setup.js should be required/imported at teh very top over every test suit file
+// setup.js should be required/imported at the very top over every test suit file.
+// technically only required for tests importing React, but making a habit to
+// import at top of every file not a bad thing, and there may come to be other 'things'
+// that need to run before any tests to setup the environment, that aren't specific to React
 
 import { jsdom } from 'jsdom';
 
-// Initialize jsdom, set global document, window, and navigator.
-// This must occur BEFORE THE FIRST require('react'), or in some cases React can throw:
+// Initialize jsdom and set global document, window, and navigator.
+// globals must be set BEFORE THE FIRST require('react'), or in some cases React can throw:
 //   "
 //      Invariant Violation: dangerouslyReplaceNodeWithMarkup(...): Cannot render markup in a
 //      worker thread. Make sure `window` and `document` are available globally before requiring
 //      React when unit testing or use ReactDOMServer.renderToString() for server rendering.
 //   "
 //
-// This was resolved by finding similar issue and solution at:
+// This was resolved by finding similar issue and solutions at:
 //     https://github.com/airbnb/enzyme/issues/58
 // and https://github.com/tmpvar/jsdom/issues/1352
 global.document = jsdom('<body></body>');

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,19 @@
+// setup.js should be required/imported at teh very top over every test suit file
+
+import { jsdom } from 'jsdom';
+
+// Initialize jsdom, set global document, window, and navigator.
+// This must occur BEFORE THE FIRST require('react'), or in some cases React can throw:
+//   "
+//      Invariant Violation: dangerouslyReplaceNodeWithMarkup(...): Cannot render markup in a
+//      worker thread. Make sure `window` and `document` are available globally before requiring
+//      React when unit testing or use ReactDOMServer.renderToString() for server rendering.
+//   "
+//
+// This was resolved by finding similar issue and solution at:
+//     https://github.com/airbnb/enzyme/issues/58
+// and https://github.com/tmpvar/jsdom/issues/1352
+global.document = jsdom('<body></body>');
+global.window = document.defaultView;
+global.navigator = window.navigator;
+

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -1,3 +1,5 @@
+import '../setup'
+
 import { expect } from 'chai';
 import { jsdom } from 'jsdom';
 

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -1,7 +1,6 @@
 import '../setup'
 
 import { expect } from 'chai';
-import { jsdom } from 'jsdom';
 
 const { Channel } = require('../../src');
 

--- a/test/unit/container.js
+++ b/test/unit/container.js
@@ -1,13 +1,11 @@
+import '../setup'
+
 import { expect } from 'chai';
 import { jsdom } from 'jsdom';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-addons-test-utils';
 import { mount, unmount } from '../utils';
-
-// Initialize jsdom
-global.document = jsdom('<body></body>');
-global.window = document.defaultView;
 
 const { Sticky, StickyContainer, Channel } = require('../../src');
 

--- a/test/unit/container.js
+++ b/test/unit/container.js
@@ -1,7 +1,6 @@
 import '../setup'
 
 import { expect } from 'chai';
-import { jsdom } from 'jsdom';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-addons-test-utils';

--- a/test/unit/sticky.js
+++ b/test/unit/sticky.js
@@ -1,7 +1,6 @@
 import '../setup'
 
 import { expect } from 'chai';
-import { jsdom } from 'jsdom';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-addons-test-utils';

--- a/test/unit/sticky.js
+++ b/test/unit/sticky.js
@@ -1,13 +1,11 @@
+import '../setup'
+
 import { expect } from 'chai';
 import { jsdom } from 'jsdom';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-addons-test-utils';
 import { mount, unmount, emitEvent } from '../utils';
-
-// Initialize jsdom
-global.document = jsdom('<body></body>');
-global.window = document.defaultView;
 
 const { Sticky, StickyContainer } = require('../../src');
 


### PR DESCRIPTION
After `jsdom` is `required()`, the global `window`, `document`, and `navigator` variables need to be set BEFORE React is required, otherwise at times React can throw:

>Invariant Violation: dangerouslyReplaceNodeWithMarkup(...): Cannot render markup in a worker thread. Make sure `window` and `document` are available globally before requiring React when unit testing or use ReactDOMServer.renderToString() for server rendering.

This issue was encountered while implementing  test's for a fix that enables asynchronously generated `<Sticky>`'s.

These similar issues were found which lead to this PR.
[https://github.com/airbnb/enzyme/issues/58]
[https://github.com/tmpvar/jsdom/issues/1352]
