### PR TITLE
Add an ability to specify custom elements for Sticky component

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -4,13 +4,16 @@ import ReactDOM from 'react-dom';
 import Channel from './channel';
 
 export default class Container extends React.Component {
-
   static contextTypes = {
     'sticky-channel': React.PropTypes.any,
   }
 
   static childContextTypes = {
     'sticky-channel': React.PropTypes.any,
+  }
+
+  static propTypes = {
+    element: React.PropTypes.string,
   }
 
   constructor(props) {
@@ -44,8 +47,7 @@ export default class Container extends React.Component {
   }
 
   render() {
-    return <div {...this.props}>
-      {this.props.children}
-    </div>
+    const { element, children, ...props } = this.props;
+    return React.createElement(element, props, children);
   }
 }

--- a/src/sticky.js
+++ b/src/sticky.js
@@ -4,6 +4,9 @@ import ReactDOM from 'react-dom';
 export default class Sticky extends React.Component {
 
   static propTypes = {
+    containerElement: React.PropTypes.string,
+    placeholderElement: React.PropTypes.string,
+    childrenElement: React.PropTypes.string,
     isActive: React.PropTypes.bool,
     className: React.PropTypes.string,
     style: React.PropTypes.object,
@@ -15,6 +18,9 @@ export default class Sticky extends React.Component {
   }
 
   static defaultProps = {
+    containerElement: 'div',
+    placeholderElement: 'div',
+    childrenElement: 'div',
     isActive: true,
     className: '',
     style: {},
@@ -187,6 +193,9 @@ export default class Sticky extends React.Component {
     }
 
     const {
+      containerElement,
+      placeholderElement,
+      childrenElement,
       topOffset,
       isActive,
       stickyClassName,
@@ -196,13 +205,17 @@ export default class Sticky extends React.Component {
       ...props
     } = this.props;
 
-    return (
-      <div>
-        <div ref="placeholder" style={placeholderStyle}></div>
-        <div {...props} ref="children" className={className} style={style}>
-          {this.props.children}
-        </div>
-      </div>
+    return React.createElement(containerElement, null,
+      React.createElement(placeholderElement, {
+        ref: 'placeholder',
+        style: placeholderStyle,
+      }),
+      React.createElement(childrenElement, {
+        ...props,
+        ref: 'children',
+        className: className,
+        style: style,
+      }, this.props.children)
     );
   }
 }


### PR DESCRIPTION
Adds the following props to `Sticky` component:
* containerElement
* placeholderElement
* childrenElement

e.g. its useful for html tables, `<thead>` tag:
```
<Sticky containerElement="thead" placeholderElement="tr" childrenElement="tr">
...
</Sticky>
```

Not sure if I'm doing this in the right way though and there are no tests covering this feature (+ need ot update readme)