### PR TITLE
Make react-sticky compatible with React 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "chai": "^3.2.0",
     "jsdom": "8.0.4",
     "mocha": "^2.2.5",
-    "react-addons-test-utils": "^0.14.0 || ^15.0.0",
+    "prop-types": "^15.5.8",
     "react": "^0.14.0 || ^15.0.0",
+    "react-addons-test-utils": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
     "rimraf": "^2.5.2",
     "webpack": "^1.12.14"

--- a/src/container.js
+++ b/src/container.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 import Channel from './channel';
@@ -6,11 +7,11 @@ import Channel from './channel';
 export default class Container extends React.Component {
 
   static contextTypes = {
-    'sticky-channel': React.PropTypes.any,
+    'sticky-channel': PropTypes.any,
   }
 
   static childContextTypes = {
-    'sticky-channel': React.PropTypes.any,
+    'sticky-channel': PropTypes.any,
   }
 
   constructor(props) {

--- a/src/sticky.js
+++ b/src/sticky.js
@@ -1,17 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 export default class Sticky extends React.Component {
 
   static propTypes = {
-    isActive: React.PropTypes.bool,
-    className: React.PropTypes.string,
-    style: React.PropTypes.object,
-    stickyClassName: React.PropTypes.string,
-    stickyStyle: React.PropTypes.object,
-    topOffset: React.PropTypes.number,
-    bottomOffset: React.PropTypes.number,
-    onStickyStateChange: React.PropTypes.func
+    isActive: PropTypes.bool,
+    className: PropTypes.string,
+    style: PropTypes.object,
+    stickyClassName: PropTypes.string,
+    stickyStyle: PropTypes.object,
+    topOffset: PropTypes.number,
+    bottomOffset: PropTypes.number,
+    onStickyStateChange: PropTypes.func
   }
 
   static defaultProps = {
@@ -26,7 +27,7 @@ export default class Sticky extends React.Component {
   }
 
   static contextTypes = {
-    'sticky-channel': React.PropTypes.any
+    'sticky-channel': PropTypes.any
   }
 
   constructor(props) {

--- a/test/unit/container.js
+++ b/test/unit/container.js
@@ -3,7 +3,7 @@ import '../setup'
 import { expect } from 'chai';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import { mount, unmount } from '../utils';
 
 const { Sticky, StickyContainer, Channel } = require('../../src');

--- a/test/unit/sticky.js
+++ b/test/unit/sticky.js
@@ -3,7 +3,7 @@ import '../setup'
 import { expect } from 'chai';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import { mount, unmount, emitEvent } from '../utils';
 
 const { Sticky, StickyContainer } = require('../../src');


### PR DESCRIPTION
This should prevent deprecation warnings introduced in React 15.5.0 from appearing when using React 15.5.0 and react-sticky.