### PR TITLE
Changed the Sticky HoC to use createElement

### DIFF
--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -85,24 +85,19 @@ export default class Sticky extends Component {
       style
     });
   };
+  
+  contentRef = content => {
+    this.content = ReactDOM.findDOMNode(content);
+  };
+  placeholderRed = placeholder => {
+    this.placeholder = placeholder
+  };
 
   render() {
-    const element = React.cloneElement(
-      this.props.children({
-        isSticky: this.state.isSticky,
-        wasSticky: this.state.wasSticky,
-        distanceFromTop: this.state.distanceFromTop,
-        distanceFromBottom: this.state.distanceFromBottom,
-        calculatedHeight: this.state.calculatedHeight,
-        style: this.state.style
-      }),
-      { ref: content => { this.content = ReactDOM.findDOMNode(content); } }
-    )
-
     return (
       <div>
-        <div ref={ placeholder => this.placeholder = placeholder } />
-        { element }
+        <div ref={this.placeholderRef} />
+        <Component {...this.state} ref={this.contentRef}/>
       </div>
     )
   }


### PR DESCRIPTION
This change makes it so that React.createElement(this.props.children) is used to construct the inner component of a <Sticky />. There are numerous benefits to this change including fixing bugs with findDOMNode when called on the result of just calling children as a function. The other big benefit of this is that you can pass in any valid component e.g.

```js
<Sticky>{class extends React.PureComponent { ... }}</Sticky>
```