### PR TITLE
Use 'react-test-renderer' package instead of 'react-addons-test-utils'

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "mocha": "^2.4.5",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "react-addons-test-utils": "^15.5.1",
+    "react-test-renderer": "^15.5.4",
     "rimraf": "^2.5.2",
     "webpack": "^2.2.0"
   }


### PR DESCRIPTION
Updated as [`recommended`](https://github.com/airbnb/enzyme#installation) in the `enzyme` package

Closes #175 

CC: @dbarbalato