### PR TITLE
set fixed top with topOffset

### DIFF
--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -67,7 +67,7 @@ export default class Sticky extends Component {
 
     const style = !isSticky ? { } : {
       position: 'fixed',
-      top: bottomDifference > 0 ? (this.props.relative ? parent.offsetTop - parent.offsetParent.scrollTop : 0) : bottomDifference,
+      top: bottomDifference > 0 ? (this.props.relative ? parent.offsetTop - parent.offsetParent.scrollTop : -this.props.topOffset) : bottomDifference,
       left: placeholderClientRect.left,
       width: placeholderClientRect.width
     }


### PR DESCRIPTION
when page already has a fixed header, sticky will overlap with the header just setting top to 0. Therefor, top of sticky should be set dynamic value with topOffset?