### PR TITLE
Fix JS error when parent node is null

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -43,14 +43,15 @@ export default class Container extends PureComponent {
       const { currentTarget } = evt;
 
       raf(() => {
+        if (this.node) {
+          const { top, bottom } = this.node.getBoundingClientRect();
+          this.subscribers.forEach(handler => handler({
+            distanceFromTop: top,
+            distanceFromBottom: bottom,
+            eventSource: currentTarget === window ? document.body : this.node
+          }));
+        }
         this.framePending = false;
-        const { top, bottom } = this.node.getBoundingClientRect();
-
-        this.subscribers.forEach(handler => handler({
-          distanceFromTop: top,
-          distanceFromBottom: bottom,
-          eventSource: currentTarget === window ? document.body : this.node
-        }));
       });
       this.framePending = true;
     }

--- a/test/spec/Container.js
+++ b/test/spec/Container.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import raf from 'raf';
 import { StickyContainer } from '../../src';
 
 const attachTo = document.getElementById('mount');
@@ -95,6 +96,24 @@ describe("StickyContainer", () => {
 
       containerNode.node.getBoundingClientRect = () => ({ top: 100, bottom: 200 });
       containerNode.notifySubscribers({ currentTarget: window });
+    });
+
+    it.only ('should not publish null node top and bottom to subscribers', (done) => {
+      let subscribersCalled = false;
+      containerNode.subscribers = [
+        () => {
+          subscribersCalled = true;
+        }
+      ];
+
+      containerNode.node = null;
+      containerNode.notifySubscribers({ currentTarget: window });
+      expect(containerNode.framePending).to.equal(true);
+      raf(() => {
+        expect(containerNode.framePending).to.equal(false);
+        expect(subscribersCalled).to.equal(false);
+        done();
+      });
     });
 
   });

--- a/test/spec/Container.js
+++ b/test/spec/Container.js
@@ -98,7 +98,7 @@ describe("StickyContainer", () => {
       containerNode.notifySubscribers({ currentTarget: window });
     });
 
-    it.only ('should not publish null node top and bottom to subscribers', (done) => {
+    it ('should not publish null node top and bottom to subscribers', (done) => {
       let subscribersCalled = false;
       containerNode.subscribers = [
         () => {


### PR DESCRIPTION
This can happen when the parent is unmounted (e.g. on react router).
With this fix, subscribers won't get notified if the parent is gone/null.

This fixes the issue described in #206.

I needed to move `this.framePending = false;` to the bottom of the code executed inside the `raf` callback. Otherwise, the test wouldn't fail when an undefined/null node throws an error.