### PR TITLE
Remove peerDep restriction against react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "raf": "^3.3.0"
   },
   "peerDependencies": {
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "react": ">=15",
+    "react-dom": ">=15"
   },
   "devDependencies": {
     "babel-cli": "^6.23.1",


### PR DESCRIPTION
Resolves #216 

I'm opting to make this `>=react@15` because nothing we're doing uses private APIs, so we should maintain compatibility. It should be considered a bug if a React release breaks this library.