### PR TITLE
Improve performance with `shouldComponentUpdate`

### DIFF
--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -49,6 +49,14 @@ export default class Sticky extends Component {
       : `${this.state.isSticky ? this.state.calculatedHeight : 0}px`;
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    const newStyle = JSON.stringify(nextState.style);
+    const oldStyle = JSON.stringify(this.state.style);
+    const styleChanged = newStyle !== oldStyle;
+
+    return (nextState.isSticky || nextState.wasSticky) && styleChanged;
+  }
+
   handleContainerEvent = ({
     distanceFromTop,
     distanceFromBottom,


### PR DESCRIPTION
We noticed that the contents of `Sticky` were getting re-rendered on every single scroll event on the entire page. We weren't taking a huge performance hit but this feels a lot better. All of the examples work as before and tests all pass so I don't think this should introduce any regressions.