### PR TITLE
Add useCapture argument to addEventListener

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -61,13 +61,13 @@ export default class Container extends PureComponent {
 
   componentDidMount() {
     this.events.forEach(event =>
-      window.addEventListener(event, this.notifySubscribers)
+      window.addEventListener(event, this.notifySubscribers, true)
     );
   }
 
   componentWillUnmount() {
     this.events.forEach(event =>
-      window.removeEventListener(event, this.notifySubscribers)
+      window.removeEventListener(event, this.notifySubscribers, true)
     );
   }
 


### PR DESCRIPTION
Hello :wave:
Thanks for this library!

I've noticed that a `<StickyContainer />` component present inside a wrapper with ~~style `overflow: auto`~~ fixed height doesn't get notified on scroll.

To fix this, this PR adds the `useCapture` argument to `addEventListener` and `removeEventListener`.

MDN doc: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener