### PR TITLE
Enable useCapture option on scroll event listener

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from "react";
 import ReactDOM from "react-dom";
 
-import { Sticky, StickyContainer } from "../../src";
-import { Header } from "../header";
+import { Sticky, StickyContainer } from "../src";
+import { Header } from "./header";
 
 let renderCount = 0;
 export class Basic extends PureComponent {

--- a/examples/capture.js
+++ b/examples/capture.js
@@ -1,0 +1,51 @@
+import React, { PureComponent } from "react";
+import ReactDOM from "react-dom";
+
+import { Sticky, StickyContainer } from "../src";
+import { Header } from "./header";
+
+const containerBg = i => `hsl(${i * 40}, 70%, 90%)`;
+const headerBg = i => `hsl(${i * 40}, 70%, 50%)`;
+
+export class Capture extends PureComponent {
+  render() {
+    return (
+      <div className="wrapper">
+        <aside className="sidebar">Sidebar</aside>
+        <div className="scroll-container">
+          <h1>Within a scrolling container</h1>
+          <div className="gap short" />
+          <StickyContainer capture={true}>
+            <div className="row">
+              <div className="column">
+                <p>
+                  Nunc consectetur placerat sem, rutrum pretium neque fringilla
+                  eget. Etiam blandit ac sem vel mollis. Aenean eros leo,
+                  ullamcorper ut luctus vitae, suscipit et libero. Duis
+                  vulputate tortor nec commodo scelerisque. Praesent fermentum
+                  diam vitae nunc ultricies condimentum. Curabitur consectetur
+                  purus nec ligula tempor finibus. Maecenas vulputate elementum
+                  felis a sagittis. Nam non malesuada ante.
+                </p>
+                <p>
+                  Nunc consectetur placerat sem, rutrum pretium neque fringilla
+                  eget. Etiam blandit ac sem vel mollis. Aenean eros leo,
+                  ullamcorper ut luctus vitae, suscipit et libero. Duis
+                  vulputate tortor nec commodo scelerisque. Praesent fermentum
+                  diam vitae nunc ultricies condimentum. Curabitur consectetur
+                  purus nec ligula tempor finibus. Maecenas vulputate elementum
+                  felis a sagittis. Nam non malesuada ante.
+                </p>
+              </div>
+
+              <div className="column">
+                <Sticky>{({ style }) => <Header style={style} />}</Sticky>
+              </div>
+            </div>
+          </StickyContainer>
+          <div className="gap tall">lots of trailing content</div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,9 +1,9 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { HashRouter as Router, Route, Redirect } from "react-router-dom";
-import { Basic } from "./basic/basic";
-import { Relative } from "./relative/relative";
-import { Stacked } from "./stacked/stacked";
+import { Basic } from "./basic";
+import { Relative } from "./relative";
+import { Stacked } from "./stacked";
 import { Navbar } from "./navbar";
 import styles from "./styles";
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -4,6 +4,7 @@ import { HashRouter as Router, Route, Redirect } from "react-router-dom";
 import { Basic } from "./basic";
 import { Relative } from "./relative";
 import { Stacked } from "./stacked";
+import { Capture } from "./capture";
 import { Navbar } from "./navbar";
 import styles from "./styles";
 
@@ -17,6 +18,7 @@ ReactDOM.render(
         <Route path="/basic" component={Basic} />
         <Route path="/relative" component={Relative} />
         <Route path="/stacked" component={Stacked} />
+        <Route path="/capture" component={Capture} />
       </div>
     </div>
   </Router>,

--- a/examples/navbar.js
+++ b/examples/navbar.js
@@ -16,6 +16,9 @@ export class Navbar extends React.Component {
           <li className="nav-link">
             <Link to="/stacked">Stacked</Link>
           </li>
+          <li className="nav-link">
+            <Link to="/capture">Capture</Link>
+          </li>
         </ul>
       </div>
     );

--- a/examples/relative.js
+++ b/examples/relative.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from "react";
 import ReactDOM from "react-dom";
 
-import { Sticky, StickyContainer } from "../../src";
-import { Header } from "../header";
+import { Sticky, StickyContainer } from "../src";
+import { Header } from "./header";
 
 let renderCount = 0;
 export class Relative extends PureComponent {

--- a/examples/stacked.js
+++ b/examples/stacked.js
@@ -1,8 +1,8 @@
 import React, { PureComponent } from "react";
 import ReactDOM from "react-dom";
 
-import { Sticky, StickyContainer } from "../../src";
-import { Header } from "../header";
+import { Sticky, StickyContainer } from "../src";
+import { Header } from "./header";
 
 const containerBg = i => `hsl(${i * 40}, 70%, 90%)`;
 const headerBg = i => `hsl(${i * 40}, 70%, 50%)`;

--- a/examples/styles.js
+++ b/examples/styles.js
@@ -11,7 +11,6 @@ body {
   font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
   padding: 0;
   margin: 0;
-  margin-top: 2rem;
   font-size: 16px;
   line-height: 1rem;
 }
@@ -71,4 +70,34 @@ h2 {
 .container.relative {
   overflow-y: auto;
 }
+
+.column {
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+  margin: 0 10px;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+}
+
+.sidebar {
+  flex-shrink: 0;
+  width: 100px;
+  background: #ddd;
+  margin-right: 20px;
+}
+
+.scroll-container {
+  overflow-y: scroll;
+}
+
+.wrapper {
+  display: flex;
+  flex: 1 1 auto;
+  height: 100vh;
+}
+
 `;

--- a/src/Container.js
+++ b/src/Container.js
@@ -3,6 +3,14 @@ import PropTypes from "prop-types";
 import raf from "raf";
 
 export default class Container extends PureComponent {
+  static propTypes = {
+    capture: PropTypes.bool
+  };
+
+  static defaultProps = {
+    capture: false
+  };
+
   static childContextTypes = {
     subscribe: PropTypes.func,
     unsubscribe: PropTypes.func,
@@ -60,21 +68,23 @@ export default class Container extends PureComponent {
   getParent = () => this.node;
 
   componentDidMount() {
+    this.capture = this.props.capture;
     this.events.forEach(event =>
-      window.addEventListener(event, this.notifySubscribers)
+      window.addEventListener(event, this.notifySubscribers, this.capture)
     );
   }
 
   componentWillUnmount() {
     this.events.forEach(event =>
-      window.removeEventListener(event, this.notifySubscribers)
+      window.removeEventListener(event, this.notifySubscribers, this.capture)
     );
   }
 
   render() {
+    const { capture, ...rest } = this.props;
     return (
       <div
-        {...this.props}
+        {...rest}
         ref={node => (this.node = node)}
         onScroll={this.notifySubscribers}
         onTouchStart={this.notifySubscribers}


### PR DESCRIPTION
Per #238 from @bdelaforest, `StickyContainer`s within elements with a fixed height don't get notified on scroll. That PR fixed it but broke the `relative` prop on `Sticky`, but I think it's a good use case to support. This PR adds a `capture` prop to `StickyContainer` to enable it.