### PR TITLE
Fixed Safari iOS rubberband issue

### DIFF
--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -74,7 +74,7 @@ export default class Sticky extends Component {
     const wasSticky = !!this.state.isSticky;
     const isSticky = preventingStickyStateChanges
       ? wasSticky
-      : distanceFromTop <= -this.props.topOffset &&
+      :  Math.min(0, distanceFromTop) <= -this.props.topOffset &&
         distanceFromBottom > -this.props.bottomOffset;
 
     distanceFromBottom =


### PR DESCRIPTION
This addresses an issue with the "rubberband" effect on iOS causing positive offset values and wrongly determine the sticky state.