### PR TITLE
Add throttleRendering prop useful for expensive render calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,19 @@ app.js
   ...
 </StickyContainer>
 ```
+
+#### throttleRendering _(default: false)_
+When `throttleRendering` is set to `true`, the function supplied to `<Sticky />` element gets invoked only when `isSticky` or  `style` properties should change. This setting is recommended when the function supplied is expensive to render and you can not rely on `shouldComponentUpdate` to optimize it. 
+
+**Note:** It is not recommended when you rely on `distanceFromTop` and `distanceFromBottom` for other computation.
+
+app.js
+```js
+<StickyContainer>
+  ...
+  <Sticky throttleRendering>
+    { ({isSticky, style, ...dontNeedRest}) => (...) }
+  </Sticky>
+  ...
+</StickyContainer>
+```

--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -15,7 +15,8 @@ export default class Sticky extends Component {
     topOffset: 0,
     bottomOffset: 0,
     disableCompensation: false,
-    disableHardwareAcceleration: false
+    disableHardwareAcceleration: false,
+    throttleRendering: false
   };
 
   static contextTypes = {
@@ -29,6 +30,8 @@ export default class Sticky extends Component {
     wasSticky: false,
     style: {}
   };
+
+  _width = 0;
 
   componentWillMount() {
     if (!this.context.subscribe)
@@ -82,6 +85,8 @@ export default class Sticky extends Component {
         ? parent.scrollHeight - parent.scrollTop
         : distanceFromBottom) - calculatedHeight;
 
+    const width = placeholderClientRect.width;
+
     const style = !isSticky
       ? {}
       : {
@@ -93,21 +98,28 @@ export default class Sticky extends Component {
                 : 0
               : bottomDifference,
           left: placeholderClientRect.left,
-          width: placeholderClientRect.width
+          width
         };
 
     if (!this.props.disableHardwareAcceleration) {
       style.transform = "translateZ(0)";
     }
 
-    this.setState({
-      isSticky,
-      wasSticky,
-      distanceFromTop,
-      distanceFromBottom,
-      calculatedHeight,
-      style
-    });
+    if ( 
+      !this.props.throttleRendering ||
+      ( wasSticky != isSticky || width != this._width)
+    ) {
+      this.setState({
+        isSticky,
+        wasSticky,
+        distanceFromTop,
+        distanceFromBottom,
+        calculatedHeight,
+        style
+      });
+    }
+
+    this._width = width;
   };
 
   render() {


### PR DESCRIPTION
Sometimes, the function supplied to `<Sticky>` element might be expensive. This prop, allows you to skip re-renders when they are not necessary.
Added documentation as well.

Thanks