### PR TITLE
Add paddingRight to placeholder for sticky in row flexbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The majority of use cases will only need the style to pass to the DOM, but some 
 * `distanceFromTop` _(number)_ - number of pixels from the top of the `Sticky` to the nearest `StickyContainer`'s top
 * `distanceFromBottom` _(number)_ - number of pixels from the bottom of the `Sticky` to the nearest `StickyContainer`'s bottom
 * `calculatedHeight` _(number)_ - height of the element returned by this function
+* `calculatedWidth` _(number)_ - width of the element returned by this function
 
 The `Sticky`'s child function will be called when events occur in the parent `StickyContainer`,
 and will serve as the callback to apply your own logic and customizations, with sane `style` attributes

--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -47,6 +47,9 @@ export default class Sticky extends Component {
     this.placeholder.style.paddingBottom = this.props.disableCompensation
       ? 0
       : `${this.state.isSticky ? this.state.calculatedHeight : 0}px`;
+    this.placeholder.style.paddingRight = this.props.disableCompensation
+      ? 0
+      : `${this.state.isSticky ? this.state.calculatedWidth : 0}px`;
   }
 
   handleContainerEvent = ({
@@ -67,6 +70,7 @@ export default class Sticky extends Component {
     const placeholderClientRect = this.placeholder.getBoundingClientRect();
     const contentClientRect = this.content.getBoundingClientRect();
     const calculatedHeight = contentClientRect.height;
+    const calculatedWidth = contentClientRect.width;
 
     const bottomDifference =
       distanceFromBottom - this.props.bottomOffset - calculatedHeight;
@@ -106,6 +110,7 @@ export default class Sticky extends Component {
       distanceFromTop,
       distanceFromBottom,
       calculatedHeight,
+      calculatedWidth,
       style
     });
   };
@@ -118,6 +123,7 @@ export default class Sticky extends Component {
         distanceFromTop: this.state.distanceFromTop,
         distanceFromBottom: this.state.distanceFromBottom,
         calculatedHeight: this.state.calculatedHeight,
+        calculatedWidth: this.state.calculatedWidth,
         style: this.state.style
       }),
       {

--- a/test/spec/Sticky.js
+++ b/test/spec/Sticky.js
@@ -109,7 +109,8 @@ describe("Valid Sticky", () => {
         style: expectedStickyStyle,
         distanceFromTop: 0,
         distanceFromBottom: 900,
-        calculatedHeight: 100
+        calculatedHeight: 100,
+        calculatedWidth: 100,
       });
       expect(parseInt(sticky.placeholder.style.paddingBottom)).to.equal(100);
     });
@@ -126,7 +127,8 @@ describe("Valid Sticky", () => {
         style: expectedStickyStyle,
         distanceFromTop: -1,
         distanceFromBottom: 899,
-        calculatedHeight: 100
+        calculatedHeight: 100,
+        calculatedWidth: 100,
       });
       expect(parseInt(sticky.placeholder.style.paddingBottom)).to.equal(100);
     });
@@ -148,7 +150,8 @@ describe("Valid Sticky", () => {
         style: expectedStickyStyle,
         distanceFromTop: -2,
         distanceFromBottom: 898,
-        calculatedHeight: 100
+        calculatedHeight: 100,
+        calculatedWidth: 100,
       });
       expect(parseInt(sticky.placeholder.style.paddingBottom)).to.equal(100);
     });
@@ -170,7 +173,8 @@ describe("Valid Sticky", () => {
         style: { transform: "translateZ(0)" },
         distanceFromTop: 1,
         distanceFromBottom: 901,
-        calculatedHeight: 100
+        calculatedHeight: 100,
+        calculatedWidth: 100,
       });
       expect(parseInt(sticky.placeholder.style.paddingBottom)).to.equal(0);
     });
@@ -187,7 +191,8 @@ describe("Valid Sticky", () => {
         style: { ...expectedStickyStyle, top: -1 },
         distanceFromTop: -901,
         distanceFromBottom: -1,
-        calculatedHeight: 100
+        calculatedHeight: 100,
+        calculatedWidth: 100,
       });
       expect(parseInt(sticky.placeholder.style.paddingBottom)).to.equal(100);
     });


### PR DESCRIPTION
This PR will add `paddingRight` to `placeholder` for sticky in row flexbox. For exmaple:

```jsx
<StickyContainer style={{display:"flex"}}>
    <Sticky>{({style}) => (
        <div style={style}>
          <div style={{width:100, height:300}}>left</div>
        </div>
    )}<Sticky>
    <div style={{width:500, height:1000}}>right</div>
</StickyContainer>
```

Without `paddingRight`, the "right div" will overlap the "left" div.