### PR TITLE
Check if `this.node` exists

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -45,6 +45,9 @@ export default class Container extends PureComponent {
 
       this.rafHandle = raf(() => {
         this.framePending = false;
+        
+        if(!this.node) return;
+        
         const { top, bottom } = this.node.getBoundingClientRect();
 
         this.subscribers.forEach(handler =>


### PR DESCRIPTION
We are getting a lot of error saying `null is not an object (evaluating 'r.node.getBoundingClientRect')`, I was not able to replicate the issue!

But this fix would be stop throwing this error.