### PR TITLE
Revert "Fixed Safari iOS rubberband issue"

### DIFF
--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -74,7 +74,7 @@ export default class Sticky extends Component {
     const wasSticky = !!this.state.isSticky;
     const isSticky = preventingStickyStateChanges
       ? wasSticky
-      :  Math.min(0, distanceFromTop) <= -this.props.topOffset &&
+      : distanceFromTop <= -this.props.topOffset &&
         distanceFromBottom > -this.props.bottomOffset;
 
     distanceFromBottom =


### PR DESCRIPTION
#254 introduced a bug (that was never released) that broke the sticky behavior. 