### PR TITLE
bugfix: invalid positioning when in relative mode (alternative solution)

### DIFF
--- a/examples/relative/relative.js
+++ b/examples/relative/relative.js
@@ -24,6 +24,24 @@ export class Relative extends PureComponent {
             <h2>scrolling container</h2>
           </div>
         </StickyContainer>
+
+        <div className="gap short" />
+
+        <StickyContainer className="container relative">
+          <div
+            className="gap tall"
+            style={{ background: "linear-gradient(#aaa, #fff)" }}
+          >
+            <div className="gap short" />
+            <Sticky relative={true} bottomOffset={600}>
+              {({ style }) => (
+                <Header style={style} renderCount={renderCount++} />
+              )}
+            </Sticky>
+            <div className="gap short" />
+            <h2>scrolling container</h2>
+          </div>
+        </StickyContainer>
       </div>
     );
   }

--- a/examples/styles.js
+++ b/examples/styles.js
@@ -69,6 +69,7 @@ h2 {
 }
 
 .container.relative {
+  position: relative;
   overflow-y: auto;
 }
 `;

--- a/src/Container.js
+++ b/src/Container.js
@@ -50,8 +50,7 @@ export default class Container extends PureComponent {
         this.subscribers.forEach(handler =>
           handler({
             distanceFromTop: top,
-            distanceFromBottom: bottom,
-            eventSource: currentTarget === window ? document.body : this.node
+            distanceFromBottom: bottom
           })
         );
       });

--- a/test/spec/Container.js
+++ b/test/spec/Container.js
@@ -77,24 +77,6 @@ describe("StickyContainer", () => {
   });
 
   describe("notifySubscribers", () => {
-    it("should publish document.body as eventSource to subscribers when window event", done => {
-      containerNode.subscribers = [
-        ({ eventSource }) => (
-          expect(eventSource).to.equal(document.body), done()
-        )
-      ];
-      containerNode.notifySubscribers({ currentTarget: window });
-    });
-
-    it("should publish node as eventSource to subscribers when div event", done => {
-      containerNode.subscribers = [
-        ({ eventSource }) => (
-          expect(eventSource).to.equal(containerNode.node), done()
-        )
-      ];
-      containerNode.notifySubscribers({ currentTarget: containerNode.node });
-    });
-
     it("should publish node top and bottom to subscribers", done => {
       containerNode.subscribers = [
         ({ distanceFromTop, distanceFromBottom }) => {


### PR DESCRIPTION
This is an alternative solution to #277 

This approach does not use `clip-path`, but does require `StickyContainer` to have `position: relative`.. this approach does goes in-line more with the spirit of `react-sticky` (providing `position: sticky` support for older browser), but it require user to manually add `position: relative` into `StickyContainer`..

alternatively, we can move `relative` prop from `Sticky` to `StickyContainer` and automatically apply both `position: relative`, `overflow-y: scroll` and maybe `-webkit-overflow-scrolling: touch;` to the `<div />` node in `StickyContainer` when `relative === true`.. but, this should be considered breaking changes I guess? wdyt?