### PR TITLE
support for transitionend event

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -24,7 +24,8 @@ export default class Container extends PureComponent {
     "touchmove",
     "touchend",
     "pageshow",
-    "load"
+    "load",
+    "transitionend"
   ];
 
   subscribers = [];


### PR DESCRIPTION
When a sticky container is on a css transition, the scroll event may fire and the transition may end after the resolution of the scroll event re-calculating the padding. This causes a possible extra space to be visible. Supporting transitionend will do a recalc to set the padding.