### PR TITLE
Adding className as a prop of Sticky component

### DIFF
--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -7,7 +7,8 @@ export default class Sticky extends Component {
     topOffset: PropTypes.number,
     bottomOffset: PropTypes.number,
     relative: PropTypes.bool,
-    children: PropTypes.func.isRequired
+    children: PropTypes.func.isRequired,
+    className: PropTypes.string
   };
 
   static defaultProps = {
@@ -15,7 +16,8 @@ export default class Sticky extends Component {
     topOffset: 0,
     bottomOffset: 0,
     disableCompensation: false,
-    disableHardwareAcceleration: false
+    disableHardwareAcceleration: false,
+    className: ''
   };
 
   static contextTypes = {
@@ -128,7 +130,7 @@ export default class Sticky extends Component {
     );
 
     return (
-      <div>
+      <div className={this.props.className}>
         <div ref={placeholder => (this.placeholder = placeholder)} />
         {element}
       </div>


### PR DESCRIPTION
The blank, unstylable div being created by this library can be frustrating.