### PR TITLE
Fix on warning: "componentWillMount will be deprecated soon"

### DIFF
--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -30,7 +30,7 @@ export default class Sticky extends Component {
     style: {}
   };
 
-  componentWillMount() {
+  componentDidMount() {
     if (!this.context.subscribe)
       throw new TypeError(
         "Expected Sticky to be mounted within StickyContainer"


### PR DESCRIPTION
Fixes the "componentWillMount will be deprecated soon" warning based on the official docs:
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#adding-event-listeners-or-subscriptions