### PR TITLE
Add didNeedCompensation callback

### DIFF
--- a/src/Sticky.js
+++ b/src/Sticky.js
@@ -44,9 +44,26 @@ export default class Sticky extends Component {
   }
 
   componentDidUpdate() {
-    this.placeholder.style.paddingBottom = this.props.disableCompensation
-      ? 0
-      : `${this.state.isSticky ? this.state.calculatedHeight : 0}px`;
+    if (this.props.disableCompensation) {
+      this.placeholder.style.paddingBottom = 0
+    } else if (this.state.isSticky) {
+      
+      if (this.props.didNeedCompensation) {
+        const targetCompensation = this.props.didNeedCompensation()
+        if (!isNaN(targetCompensation)) {
+          this.placeholder.style.paddingBottom = `${targetCompensation}px`
+        } else {
+          throw new TypeError(
+            "Expected didNeedCompensation to return a number"
+          );
+        }
+       
+      } else {
+        this.placeholder.style.paddingBottom = `${this.state.calculatedHeight}px`
+      }
+    } else {
+      this.placeholder.style.paddingBottom = 0
+    }
   }
 
   handleContainerEvent = ({

--- a/test/spec/Sticky.js
+++ b/test/spec/Sticky.js
@@ -390,4 +390,47 @@ describe("Valid Sticky", () => {
       expect(parseInt(sticky.placeholder.style.paddingBottom)).to.equal(0);
     });
   });
+
+  describe("with didNeedCompensation defined", () => {
+    it("should get compensation padding from props function", () => {
+      const wrapper = mount(
+        componentFactory({
+          didNeedCompensation: () => {
+            return 123
+          },
+          children: () => <div />
+        }),
+        { attachTo }
+      );
+
+      const sticky = wrapper.children().node;
+      sticky.handleContainerEvent({
+        distanceFromTop: -1,
+        distanceFromBottom: 99,
+        eventSource: document.body
+      });
+      expect(sticky.state.isSticky).to.be.true;
+      expect(parseInt(sticky.placeholder.style.paddingBottom)).to.equal(123);
+    });
+
+    it("should complain if compensation callback does not return a number", () => {
+      const wrapper = mount(
+        componentFactory({
+          didNeedCompensation: () => {
+            return 'to fail'
+          },
+          children: () => <div />
+        }),
+        { attachTo }
+      );
+
+      const sticky = wrapper.children().node;
+      expect(() => sticky.handleContainerEvent({
+          distanceFromTop: -1,
+          distanceFromBottom: 99,
+          eventSource: document.body
+        })
+      ).to.throw(TypeError);
+    });
+  });
 });


### PR DESCRIPTION
## Add didNeedCompensation param to Sticky component

Use didNeedCompensation function to get padding-bottom for the compensation layer.

I needed this because my sticky has a dynamic height.

And if compensation gets updated with it the page content will not "sync" with the dynamic height on scroll and will go under the sticky before it should. So in my case, I needed a fixed compensation value.


